### PR TITLE
Enhance usability of sensibo_client.py on the command line

### DIFF
--- a/sensibo_client.py
+++ b/sensibo_client.py
@@ -34,43 +34,73 @@ class SensiboClientAPI(object):
     def pod_change_ac_state(self, podUid, currentAcState, propertyToChange, newValue):
         self._patch("/pods/%s/acStates/%s" % (podUid, propertyToChange),
                 json.dumps({'currentAcState': currentAcState, 'newValue': newValue}))
+  
+def tempFromMeasurements(measurement):
+    if (args.unitC):
+      return (str(measurement["temperature"]) + 'C' )
+    elif (args.unitF):
+      return (str(round(measurement["temperature"]*(9/5)+32,1)) + 'F')
 
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Sensibo client example parser')
     parser.add_argument('apikey', type = str, help='Obtain from https://home.sensibo.com/me/api')
     parser.add_argument('--deviceName', type = str, help='Device name')
+    parser.add_argument('--allDevices', action='store_true', help='Query all devices')
     parser.add_argument('--showState', action='store_true',help='Display the AC state')
     parser.add_argument('--showMeasurement', action='store_true',help='Display the sensor measurements')
+    parser.add_argument('--showTempMeasurement', action='store_true',help='Display the sensor temperature')
+    parser.add_argument('--unitF', action='store_true',help='Use Fahrenheit')
+    parser.add_argument('--unitC', action='store_true',help='Use Celsius')
     args = parser.parse_args()
     #print(args)
+    if (not args.unitF and not args.unitC):
+      args.unitC=True 
 
     client = SensiboClientAPI(args.apikey)
     try:
       devices = client.devices()
-      print ("-" * 10, "devices", "-" * 10)
-      print (devices)
+      if(not args.deviceName and not args.allDevices):
+        print ("-" * 10, "devices", "-" * 10)
+        print (devices)
     except requests.exceptions.RequestException as exc:
       print ("Request failed with message %s" % exc)
-      exit(1)
+      devices = {'living room A/C': 'ntZFS9SF', 'bedroom A/C': 'wwyyJdeY', "Megan's A/C": 'f3uEc9GG'}
+      #exit(1)
  
-    if(args.deviceName):
-      try: 
-        uid = devices[args.deviceName]
-        #Default to showing AC state since a device was specified without a clear reason
-        if(not args.showState and not args.showMeasurement):
-          args.showState=True 
-     
-        if(args.showState and uid):
-          ac_state = client.pod_ac_state(uid)
-          print ("-" * 10, "AC State of %s" % args.deviceName, "-" * 10)
-          print (ac_state)
-        if(args.showMeasurement and uid):
-          pod_measurement = client.pod_measurement(uid)
-          print ("-" * 10, "Measurement of %s" % args.deviceName, "-" * 10)
-          print (pod_measurement)
+    if(args.deviceName and not args.allDevices):
+      uidList = [devices[args.deviceName]]
+      deviceNameByUID = {devices[args.deviceName]:args.deviceName}
+    elif(args.allDevices):
+      uidList = devices.values()
+      deviceNameByUID = {v:k for k,v in devices.items()}
+    else:
+      uidList = False
 
-        #client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
+    #A specific device or all devices were requested
+    if (uidList): 
+      #Default to showing AC state since no particular information request was given
+      if(not args.showState and not args.showMeasurement and not args.showTempMeasurement):
+        args.showState=True 
+      
+      try: 
+        for uid in uidList:
+          #print ("UID {}".format(uid))
+          #continue 
+          if(args.showState):
+            ac_state = client.pod_ac_state(uid)
+            print ("-" * 10, "AC State of %s" % deviceNameByUID[uid], "-" * 10)
+            print (ac_state)
+          if(args.showMeasurement or args.showTempMeasurement):
+            pod_measurement = client.pod_measurement(uid)
+          if(args.showMeasurement):
+            print ("-" * 10, "Measurement of %s" % deviceNameByUID[uid], "-" * 10)
+            print (pod_measurement)
+          if(args.showTempMeasurement):
+            print ("-" * 10, "Temperature in %s" % deviceNameByUID[uid], "-" * 10)
+            print (tempFromMeasurements(pod_measurement[0]))
+
+          #client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
       except requests.exceptions.RequestException as exc:
         print ("Request failed with message %s" % exc)
         exit(1)

--- a/sensibo_client.py
+++ b/sensibo_client.py
@@ -82,8 +82,7 @@ if __name__ == "__main__":
         print (devices)
     except requests.exceptions.RequestException as exc:
       print ("Request failed with message %s" % exc)
-      devices = {'living room A/C': 'ntZFS9SF', 'bedroom A/C': 'wwyyJdeY', "Megan's A/C": 'f3uEc9GG'}
-      #exit(1)
+      exit(1)
  
     if(args.deviceName and not args.allDevices):
       uidList = [devices[args.deviceName]]

--- a/sensibo_client.py
+++ b/sensibo_client.py
@@ -38,19 +38,39 @@ class SensiboClientAPI(object):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Sensibo client example parser')
-    parser.add_argument('apikey', type = str)
-    parser.add_argument('--deviceName', type = str)
+    parser.add_argument('apikey', type = str, help='Obtain from https://home.sensibo.com/me/api')
+    parser.add_argument('--deviceName', type = str, help='Device name')
+    parser.add_argument('--showState', action='store_true',help='Display the AC state')
+    parser.add_argument('--showMeasurement', action='store_true',help='Display the sensor measurements')
     args = parser.parse_args()
+    #print(args)
 
     client = SensiboClientAPI(args.apikey)
-    devices = client.devices()
-    print ("-" * 10, "devices", "-" * 10)
-    print (devices)
-
+    try:
+      devices = client.devices()
+      print ("-" * 10, "devices", "-" * 10)
+      print (devices)
+    except requests.exceptions.RequestException as exc:
+      print ("Request failed with message %s" % exc)
+      exit(1)
+ 
     if(args.deviceName):
-      uid = devices[args.deviceName]
-      ac_state = client.pod_ac_state(uid)
-      print ("-" * 10, "AC State of %s" % args.deviceName, "_" * 10)
-      print (ac_state)
+      try: 
+        uid = devices[args.deviceName]
+        #Default to showing AC state since a device was specified without a clear reason
+        if(not args.showState and not args.showMeasurement):
+          args.showState=True 
+     
+        if(args.showState and uid):
+          ac_state = client.pod_ac_state(uid)
+          print ("-" * 10, "AC State of %s" % args.deviceName, "-" * 10)
+          print (ac_state)
+        if(args.showMeasurement and uid):
+          pod_measurement = client.pod_measurement(uid)
+          print ("-" * 10, "Measurement of %s" % args.deviceName, "-" * 10)
+          print (pod_measurement)
 
-#      client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
+        #client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
+      except requests.exceptions.RequestException as exc:
+        print ("Request failed with message %s" % exc)
+        exit(1)

--- a/sensibo_client.py
+++ b/sensibo_client.py
@@ -39,17 +39,18 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Sensibo client example parser')
     parser.add_argument('apikey', type = str)
-    parser.add_argument('deviceName', type = str)
+    parser.add_argument('--deviceName', type = str)
     args = parser.parse_args()
 
     client = SensiboClientAPI(args.apikey)
     devices = client.devices()
-    print "-" * 10, "devices", "-" * 10
-    print devices
+    print ("-" * 10, "devices", "-" * 10)
+    print (devices)
 
-    uid = devices[args.deviceName]
-    ac_state = client.pod_ac_state(uid)
-    print "-" * 10, "AC State of %s" % args.deviceName, "_" * 10
-    print ac_state
+    if(args.deviceName):
+      uid = devices[args.deviceName]
+      ac_state = client.pod_ac_state(uid)
+      print ("-" * 10, "AC State of %s" % args.deviceName, "_" * 10)
+      print (ac_state)
 
-    client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
+#      client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 

--- a/sensibo_client.py
+++ b/sensibo_client.py
@@ -36,10 +36,24 @@ class SensiboClientAPI(object):
                 json.dumps({'currentAcState': currentAcState, 'newValue': newValue}))
   
 def tempFromMeasurements(measurement):
+    unitId=''
     if (args.unitC):
-      return (str(measurement["temperature"]) + 'C' )
+      if(not args.terse):
+         unitId='C'
+      return (str(measurement["temperature"]) + unitId )
     elif (args.unitF):
-      return (str(round(measurement["temperature"]*(9/5)+32,1)) + 'F')
+      if(not args.terse):
+         unitId='F'
+      return (str(round(measurement["temperature"]*(9/5)+32,1)) + unitId)
+    elif (args.unitDual):
+      if(not args.terse):
+         unitId='F'
+         unitId2='C'
+         unitIdSep=' / '
+      else:
+         unitId2=''
+         unitIdSep=' / '   
+      return (str(round(measurement["temperature"]*(9/5)+32,1)) + unitId + unitIdSep +str(measurement["temperature"]) + unitId2)
 
 if __name__ == "__main__":
     import argparse
@@ -48,13 +62,16 @@ if __name__ == "__main__":
     parser.add_argument('--deviceName', type = str, help='Device name')
     parser.add_argument('--allDevices', action='store_true', help='Query all devices')
     parser.add_argument('--showState', action='store_true',help='Display the AC state')
-    parser.add_argument('--showMeasurement', action='store_true',help='Display the sensor measurements')
+    parser.add_argument('--togglePower', action='store_true',help='Toggle the AC power')
+    parser.add_argument('--showMeasurements', action='store_true',help='Display the sensor measurements')
     parser.add_argument('--showTempMeasurement', action='store_true',help='Display the sensor temperature')
     parser.add_argument('--unitF', action='store_true',help='Use Fahrenheit')
     parser.add_argument('--unitC', action='store_true',help='Use Celsius')
+    parser.add_argument('--unitDual', action='store_true',help='Use F/C')
+    parser.add_argument('--terse', action='store_true',help='Keep the response short')
     args = parser.parse_args()
     #print(args)
-    if (not args.unitF and not args.unitC):
+    if (not args.unitF and not args.unitC and not args.unitDual):
       args.unitC=True 
 
     client = SensiboClientAPI(args.apikey)
@@ -80,27 +97,31 @@ if __name__ == "__main__":
     #A specific device or all devices were requested
     if (uidList): 
       #Default to showing AC state since no particular information request was given
-      if(not args.showState and not args.showMeasurement and not args.showTempMeasurement):
+      if(not args.showState and not args.showMeasurements and not args.showTempMeasurement):
         args.showState=True 
       
       try: 
         for uid in uidList:
           #print ("UID {}".format(uid))
-          #continue 
-          if(args.showState):
+          #continue
+          if(args.terse and args.allDevices):
+            print(deviceNameByUID[uid])
+          if(args.showState or args.togglePower):
             ac_state = client.pod_ac_state(uid)
-            print ("-" * 10, "AC State of %s" % deviceNameByUID[uid], "-" * 10)
+          if(args.showState):
+            not args.terse and print ("-" * 10, "AC State of %s" % deviceNameByUID[uid], "-" * 10)
             print (ac_state)
-          if(args.showMeasurement or args.showTempMeasurement):
+          if(args.togglePower):
+            client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
+          if(args.showMeasurements or args.showTempMeasurement):
             pod_measurement = client.pod_measurement(uid)
-          if(args.showMeasurement):
-            print ("-" * 10, "Measurement of %s" % deviceNameByUID[uid], "-" * 10)
+          if(args.showMeasurements):
+            not args.terse and print ("-" * 10, "Measurement of %s" % deviceNameByUID[uid], "-" * 10)
             print (pod_measurement)
           if(args.showTempMeasurement):
-            print ("-" * 10, "Temperature in %s" % deviceNameByUID[uid], "-" * 10)
+            not args.terse and print ("-" * 10, "Temperature in %s" % deviceNameByUID[uid], "-" * 10)
             print (tempFromMeasurements(pod_measurement[0]))
 
-          #client.pod_change_ac_state(uid, ac_state, "on", not ac_state['on']) 
       except requests.exceptions.RequestException as exc:
         print ("Request failed with message %s" % exc)
         exit(1)


### PR DESCRIPTION
I've added a number of switches and logic so that sensibo_client.py will make it easier to interact with your devices on the command line. For example, list devices when no device specified, query or toggle one or all devices. query for temperature.